### PR TITLE
Refactor irisApiType

### DIFF
--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -7,9 +7,8 @@ import {
 import { irisApiId } from '../../index';
 
 describe('irisApiId', () => {
-  it('return full api type with hash code', () => {
-    let myClass = { name: 'MyClass' } as Clazz;
-    let mf = {
+  it('full api type for overload function with hash code', () => {
+    let mf1 = {
       name: 'MyFunc',
       parameters: [
         {
@@ -19,15 +18,30 @@ describe('irisApiId', () => {
         } as Variable,
       ],
     } as MemberFunction;
+    let mf2 = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+        {
+          type: {
+            source: 'int',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+    let myClass = { name: 'MyClass', methods: [mf1, mf2] } as Clazz;
 
-    let apiType = irisApiId(myClass, mf);
+    let apiType = irisApiId(myClass, mf1);
 
     expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
   });
 
-  it('return full api type with hash code with so long parameter type name', () => {
-    let myClass = { name: 'MyClass' } as Clazz;
-    let mf = {
+  it('full api type for overload function with hash code with so long parameter type name', () => {
+    let mf1 = {
       name: 'MyFunc',
       parameters: [
         {
@@ -38,13 +52,62 @@ describe('irisApiId', () => {
         } as Variable,
       ],
     } as MemberFunction;
+    let mf2 = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+        {
+          type: {
+            source: 'int',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+    let myClass = { name: 'MyClass', methods: [mf1, mf2] } as Clazz;
 
-    let apiType = irisApiId(myClass, mf);
+    let apiType = irisApiId(myClass, mf1);
 
     expect(apiType).toBe('MYCLASS_MYFUNC_67d36c93');
   });
 
-  it('return full api type with hash code, toUpperCase = false', () => {
+  it('full api type for overload function with hash code, toUpperCase = false', () => {
+    let mf1 = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+    let mf2 = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+        {
+          type: {
+            source: 'int',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+    let myClass = { name: 'MyClass', methods: [mf1, mf2] } as Clazz;
+
+    let apiType = irisApiId(myClass, mf1, { toUpperCase: false });
+
+    expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
+  });
+
+  it('api id for non overload function', () => {
     let myClass = { name: 'MyClass' } as Clazz;
     let mf = {
       name: 'MyFunc',
@@ -57,12 +120,48 @@ describe('irisApiId', () => {
       ],
     } as MemberFunction;
 
-    let apiType = irisApiId(myClass, mf, { toUpperCase: false });
+    let apiType = irisApiId(myClass, mf);
 
-    expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
+    expect(apiType).toBe('MYCLASS_MYFUNC');
   });
 
-  it('return hash code only', () => {
+  it('api id for non overload function without class name', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+
+    let apiType = irisApiId(myClass, mf, { withClassName: false });
+
+    expect(apiType).toBe('MYFUNC');
+  });
+
+  it('api id for non overload function without function name', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+
+    let apiType = irisApiId(myClass, mf, { withFuncName: false });
+
+    expect(apiType).toBe('MYCLASS');
+  });
+
+  it('empty api id for non overload function', () => {
     let myClass = { name: 'MyClass' } as Clazz;
     let mf = {
       name: 'MyFunc',
@@ -80,6 +179,6 @@ describe('irisApiId', () => {
       withFuncName: false,
     });
 
-    expect(apiType).toBe('3766a1b9');
+    expect(apiType).toBe('');
   });
 });

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -1,77 +1,85 @@
-import path from 'path';
+import {
+  Clazz,
+  MemberFunction,
+  Variable,
+} from '@agoraio-extensions/cxx-parser';
+
 import { irisApiType } from '../../index';
-import { Clazz, MemberFunction, Variable } from '@agoraio-extensions/cxx-parser';
 
 describe('irisApiType', () => {
-    it('return full api type with hash code', () => {
-        let myClass = { name: 'MyClass' } as Clazz;
-        let mf = {
-            name: 'MyFunc',
-            parameters: [
-                {
-                    type: {
-                        source: 'const char *'
-                    }
-                } as Variable
-            ]
-        } as MemberFunction;
+  it('return full api type with hash code', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
 
-        let apiType = irisApiType(myClass, mf,);
+    let apiType = irisApiType(myClass, mf);
 
-        expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
+    expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
+  });
+
+  it('return full api type with hash code with so long parameter type name', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source:
+              'ThisIsASoLooooooooooooooooongNamespace1::ThisIsASoLooooooooooooooooongNamespace2::ThisIsASoLooooooooooooooooongNamespace3::ThisIsASoLooooooooooooooooongClass',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+
+    let apiType = irisApiType(myClass, mf);
+
+    expect(apiType).toBe('MYCLASS_MYFUNC_67d36c93');
+  });
+
+  it('return full api type with hash code, toUpperCase = false', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+
+    let apiType = irisApiType(myClass, mf, { toUpperCase: false });
+
+    expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
+  });
+
+  it('return hash code only', () => {
+    let myClass = { name: 'MyClass' } as Clazz;
+    let mf = {
+      name: 'MyFunc',
+      parameters: [
+        {
+          type: {
+            source: 'const char *',
+          },
+        } as Variable,
+      ],
+    } as MemberFunction;
+
+    let apiType = irisApiType(myClass, mf, {
+      withClassName: false,
+      withFuncName: false,
     });
 
-    it('return full api type with hash code with so long parameter type name', () => {
-        let myClass = { name: 'MyClass' } as Clazz;
-        let mf = {
-            name: 'MyFunc',
-            parameters: [
-                {
-                    type: {
-                        source: 'ThisIsASoLooooooooooooooooongNamespace1::ThisIsASoLooooooooooooooooongNamespace2::ThisIsASoLooooooooooooooooongNamespace3::ThisIsASoLooooooooooooooooongClass'
-                    }
-                } as Variable
-            ]
-        } as MemberFunction;
-
-        let apiType = irisApiType(myClass, mf,);
-
-        expect(apiType).toBe('MYCLASS_MYFUNC_67d36c93');
-    });
-
-    it('return full api type with hash code, toUpperCase = false', () => {
-        let myClass = { name: 'MyClass' } as Clazz;
-        let mf = {
-            name: 'MyFunc',
-            parameters: [
-                {
-                    type: {
-                        source: 'const char *'
-                    }
-                } as Variable
-            ]
-        } as MemberFunction;
-
-        let apiType = irisApiType(myClass, mf, { toUpperCase: false });
-
-        expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
-    });
-
-    it('return hash code only', () => {
-        let myClass = { name: 'MyClass' } as Clazz;
-        let mf = {
-            name: 'MyFunc',
-            parameters: [
-                {
-                    type: {
-                        source: 'const char *'
-                    }
-                } as Variable
-            ]
-        } as MemberFunction;
-
-        let apiType = irisApiType(myClass, mf, { returnHashCodeOnly: true });
-
-        expect(apiType).toBe('3766a1b9');
-    });
+    expect(apiType).toBe('3766a1b9');
+  });
 });

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -4,9 +4,9 @@ import {
   Variable,
 } from '@agoraio-extensions/cxx-parser';
 
-import { irisApiType } from '../../index';
+import { irisApiId } from '../../index';
 
-describe('irisApiType', () => {
+describe('irisApiId', () => {
   it('return full api type with hash code', () => {
     let myClass = { name: 'MyClass' } as Clazz;
     let mf = {
@@ -20,7 +20,7 @@ describe('irisApiType', () => {
       ],
     } as MemberFunction;
 
-    let apiType = irisApiType(myClass, mf);
+    let apiType = irisApiId(myClass, mf);
 
     expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
   });
@@ -39,7 +39,7 @@ describe('irisApiType', () => {
       ],
     } as MemberFunction;
 
-    let apiType = irisApiType(myClass, mf);
+    let apiType = irisApiId(myClass, mf);
 
     expect(apiType).toBe('MYCLASS_MYFUNC_67d36c93');
   });
@@ -57,7 +57,7 @@ describe('irisApiType', () => {
       ],
     } as MemberFunction;
 
-    let apiType = irisApiType(myClass, mf, { toUpperCase: false });
+    let apiType = irisApiId(myClass, mf, { toUpperCase: false });
 
     expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
   });
@@ -75,7 +75,7 @@ describe('irisApiType', () => {
       ],
     } as MemberFunction;
 
-    let apiType = irisApiType(myClass, mf, {
+    let apiType = irisApiId(myClass, mf, {
       withClassName: false,
       withFuncName: false,
     });

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -18,7 +18,7 @@ describe('irisApiType', () => {
 
         let apiType = irisApiType(myClass, mf);
 
-        expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
+        expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
     });
 
     it('return hash code only', () => {

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -1,0 +1,41 @@
+import path from 'path';
+import { irisApiType } from '../../index';
+import { Clazz, MemberFunction, Variable } from '@agoraio-extensions/cxx-parser';
+
+describe('irisApiType', () => {
+    it('return full api type with hash code', () => {
+        let myClass = { name: 'MyClass' } as Clazz;
+        let mf = {
+            name: 'MyFunc',
+            parameters: [
+                {
+                    type: {
+                        source: 'const char *'
+                    }
+                } as Variable
+            ]
+        } as MemberFunction;
+
+        let apiType = irisApiType(myClass, mf);
+
+        expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
+    });
+
+    it('return hash code only', () => {
+        let myClass = { name: 'MyClass' } as Clazz;
+        let mf = {
+            name: 'MyFunc',
+            parameters: [
+                {
+                    type: {
+                        source: 'const char *'
+                    }
+                } as Variable
+            ]
+        } as MemberFunction;
+
+        let apiType = irisApiType(myClass, mf, true);
+
+        expect(apiType).toBe('3766a1b9');
+    });
+});

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -16,9 +16,27 @@ describe('irisApiType', () => {
             ]
         } as MemberFunction;
 
-        let apiType = irisApiType(myClass, mf);
+        let apiType = irisApiType(myClass, mf,);
 
         expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
+    });
+
+    it('return full api type with hash code, toUpperCase = false', () => {
+        let myClass = { name: 'MyClass' } as Clazz;
+        let mf = {
+            name: 'MyFunc',
+            parameters: [
+                {
+                    type: {
+                        source: 'const char *'
+                    }
+                } as Variable
+            ]
+        } as MemberFunction;
+
+        let apiType = irisApiType(myClass, mf, { toUpperCase: false });
+
+        expect(apiType).toBe('MyClass_MyFunc_3766a1b9');
     });
 
     it('return hash code only', () => {
@@ -34,7 +52,7 @@ describe('irisApiType', () => {
             ]
         } as MemberFunction;
 
-        let apiType = irisApiType(myClass, mf, true);
+        let apiType = irisApiType(myClass, mf, { returnHashCodeOnly: true });
 
         expect(apiType).toBe('3766a1b9');
     });

--- a/src/__tests__/utils/iris_utils.test.ts
+++ b/src/__tests__/utils/iris_utils.test.ts
@@ -21,6 +21,24 @@ describe('irisApiType', () => {
         expect(apiType).toBe('MYCLASS_MYFUNC_3766a1b9');
     });
 
+    it('return full api type with hash code with so long parameter type name', () => {
+        let myClass = { name: 'MyClass' } as Clazz;
+        let mf = {
+            name: 'MyFunc',
+            parameters: [
+                {
+                    type: {
+                        source: 'ThisIsASoLooooooooooooooooongNamespace1::ThisIsASoLooooooooooooooooongNamespace2::ThisIsASoLooooooooooooooooongNamespace3::ThisIsASoLooooooooooooooooongClass'
+                    }
+                } as Variable
+            ]
+        } as MemberFunction;
+
+        let apiType = irisApiType(myClass, mf,);
+
+        expect(apiType).toBe('MYCLASS_MYFUNC_67d36c93');
+    });
+
     it('return full api type with hash code, toUpperCase = false', () => {
         let myClass = { name: 'MyClass' } as Clazz;
         let mf = {

--- a/src/utils/iris_utils.ts
+++ b/src/utils/iris_utils.ts
@@ -3,15 +3,16 @@ import {
   MemberFunction,
   SimpleTypeKind,
 } from '@agoraio-extensions/cxx-parser';
+import { execSync } from 'child_process';
 
 /**
- * Return the API type schema `<Class Name Uppercase>_<Function Name Uppercase>_<Full API Type Hash Code>`.
+ * Return the API type schema `<Class Name [Uppercase]>_<Function Name [Uppercase]>_<Full API Type Hash Code>`.
  * @param clazz The `Clazz`
  * @param mf The `MemberFunction`
  * @param returnHashCodeOnly Only return the hash code string
  * @returns 
  */
-export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly = false): string {
+export function irisApiType(clazz: Clazz, mf: MemberFunction, options?: { returnHashCodeOnly?: boolean, toUpperCase?: boolean }): string {
   // Borrow from https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
   function _stringHashCode(source: string): number {
     let length = source.length;
@@ -28,6 +29,8 @@ export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly
   const seperator = '__';
   const shortSeperator = '_';
 
+  let returnHashCodeOnly = options?.returnHashCodeOnly ?? false;
+  let toUpperCase = options?.toUpperCase ?? true;
 
   let ps = mf.parameters
     .map((param) => {
@@ -43,7 +46,15 @@ export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly
     return hc;
   }
 
+  let cn = clazz.name.trimNamespace();
+  let mn = mf.name;
+
+  if (toUpperCase) {
+    cn = cn.toUpperCase();
+    mn = mn.toUpperCase();
+  }
+
   // We use single one underscore `shortSeperator` for display purpose
-  // <Class Name Uppercase>_<Function Name Uppercase>_<Full API Type Hash Code>
-  return `${clazz.name.trimNamespace().toUpperCase()}${shortSeperator}${mf.name.toUpperCase()}${shortSeperator}${hc}`;
+  // <Class Name [Uppercase]>_<Function Name [Uppercase]>_<Full API Type Hash Code>
+  return `${cn}${shortSeperator}${mn}${shortSeperator}${hc}`;
 }

--- a/src/utils/iris_utils.ts
+++ b/src/utils/iris_utils.ts
@@ -5,7 +5,7 @@ import {
 } from '@agoraio-extensions/cxx-parser';
 
 /**
- * Return the API type schema `<Class Name>_<Function Name>_<Full API Type Hash Code>`.
+ * Return the API type schema `<Class Name Uppercase>_<Function Name Uppercase>_<Full API Type Hash Code>`.
  * @param clazz The `Clazz`
  * @param mf The `MemberFunction`
  * @param returnHashCodeOnly Only return the hash code string
@@ -44,6 +44,6 @@ export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly
   }
 
   // We use single one underscore `shortSeperator` for display purpose
-  // <Class Name>_<Function Name>_<Full API Type Hash Code>
-  return `${clazz.name.trimNamespace()}${shortSeperator}${mf.name}${shortSeperator}${hc}`;
+  // <Class Name Uppercase>_<Function Name Uppercase>_<Full API Type Hash Code>
+  return `${clazz.name.trimNamespace().toUpperCase()}${shortSeperator}${mf.name.toUpperCase}${shortSeperator}${hc}`;
 }

--- a/src/utils/iris_utils.ts
+++ b/src/utils/iris_utils.ts
@@ -4,28 +4,46 @@ import {
   SimpleTypeKind,
 } from '@agoraio-extensions/cxx-parser';
 
-export function irisApiType(clazz: Clazz, mf: MemberFunction): string {
-  const ptrEscape = 'ptr';
-  const refEscape = 'ref';
-  const whitespaceEscape = '_';
+/**
+ * Return the API type schema `<Class Name>_<Function Name>_<Full API Type Hash Code>`.
+ * @param clazz The `Clazz`
+ * @param mf The `MemberFunction`
+ * @param returnHashCodeOnly Only return the hash code string
+ * @returns 
+ */
+export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly = false): string {
+  // Borrow from https://stackoverflow.com/questions/7616461/generate-a-hash-from-string-in-javascript
+  function _stringHashCode(source: string): number {
+    let length = source.length;
+    let hash = 0, i, chr;
+    if (length === 0) return hash;
+    for (i = 0; i < length; i++) {
+      chr = source.charCodeAt(i);
+      hash = ((hash << 5) - hash) + chr;
+      hash |= 0; // Convert to 32bit integer
+    }
+    return hash;
+  }
+
   const seperator = '__';
+  const shortSeperator = '_';
+
 
   let ps = mf.parameters
     .map((param) => {
-      let out = param.type.name.replaceAll('::', whitespaceEscape);
-
-      if (param.type.is_const) {
-        out = `const${whitespaceEscape}${out}`;
-      }
-      if (param.type.kind === SimpleTypeKind.pointer_t) {
-        out += `${whitespaceEscape}${ptrEscape}`;
-      } else if (param.type.kind === SimpleTypeKind.reference_t) {
-        out += `${whitespaceEscape}${refEscape}`;
-      }
-
-      return out;
+      return param.type.source;
     })
     .join(seperator);
 
-  return `${clazz.name.trimNamespace()}${seperator}${mf.name}${seperator}${ps}`;
+  // <Class Name>__<Function Name>__<Param Type1>__<Param Type2>__<...>
+  let apiType = `${clazz.name.trimNamespace()}${seperator}${mf.name}${seperator}${ps}`;
+  // Convert to hex string
+  let hc = _stringHashCode(apiType).toString(16);
+  if (returnHashCodeOnly) {
+    return hc;
+  }
+
+  // We use single one underscore `shortSeperator` for display purpose
+  // <Class Name>_<Function Name>_<Full API Type Hash Code>
+  return `${clazz.name.trimNamespace()}${shortSeperator}${mf.name}${shortSeperator}${hc}`;
 }

--- a/src/utils/iris_utils.ts
+++ b/src/utils/iris_utils.ts
@@ -7,7 +7,7 @@ import { Clazz, MemberFunction } from '@agoraio-extensions/cxx-parser';
  * @param returnHashCodeOnly Only return the hash code string
  * @returns
  */
-export function irisApiType(
+export function irisApiId(
   clazz: Clazz,
   mf: MemberFunction,
   options?: {

--- a/src/utils/iris_utils.ts
+++ b/src/utils/iris_utils.ts
@@ -45,5 +45,5 @@ export function irisApiType(clazz: Clazz, mf: MemberFunction, returnHashCodeOnly
 
   // We use single one underscore `shortSeperator` for display purpose
   // <Class Name Uppercase>_<Function Name Uppercase>_<Full API Type Hash Code>
-  return `${clazz.name.trimNamespace().toUpperCase()}${shortSeperator}${mf.name.toUpperCase}${shortSeperator}${hc}`;
+  return `${clazz.name.trimNamespace().toUpperCase()}${shortSeperator}${mf.name.toUpperCase()}${shortSeperator}${hc}`;
 }


### PR DESCRIPTION
- Refactor irisApiType to return the API type schema `<Class Name [Uppercase]>_<Function Name [Uppercase]>[_<Full API Type Hash Code>]`.
- Rename `irisApiType` -> `irisApiId`