### PR TITLE
[IrisDocRenderer][dart] Format files before running the iris_doc.py

### DIFF
--- a/src/__tests__/renderers/iris_doc_renderer.test.ts
+++ b/src/__tests__/renderers/iris_doc_renderer.test.ts
@@ -99,18 +99,19 @@ describe('IrisDocRenderer', () => {
     let fmtConfigPath = path.join(irisDocDir, 'fmt_config', 'fmt_dart.yaml');
     let irisDocCommand = `python3 ${irisDocScriptPath} --config=${fmtConfigPath} --language=dart --export-file-path=${exportFilePath} --template-url=https://exampe.com`;
     // - 1 time for git clone
+    // - 1 time for dart format
     // - 1 time for python install requirements.txt
     // - 1 time for iris-doc.py
-    expect(execSync).toBeCalledTimes(3);
+    expect(execSync).toBeCalledTimes(4);
     expect(execSync).toHaveBeenNthCalledWith(
-      2,
+      3,
       `python3 -m pip install -r ${path.join(irisDocDir, 'requirements.txt')}`,
       {
         encoding: 'utf8',
         stdio: 'inherit',
       }
     );
-    expect(execSync).toHaveBeenNthCalledWith(3, irisDocCommand, {
+    expect(execSync).toHaveBeenNthCalledWith(4, irisDocCommand, {
       encoding: 'utf8',
       stdio: 'inherit',
     });

--- a/src/renderers/iris_doc_renderer.ts
+++ b/src/renderers/iris_doc_renderer.ts
@@ -38,16 +38,6 @@ function irisDocScript(
   exportFilePath: string,
   templateUrl: string
 ) {
-  let requirementsPath = path.join(irisDocDir, 'requirements.txt');
-  let installRequirements = `python3 -m pip install -r ${requirementsPath}`;
-  const installRequirementsOut = execSync(installRequirements, {
-    encoding: 'utf8',
-    stdio: 'inherit',
-  });
-  console.log(installRequirementsOut);
-
-  let fmtConfigPath = path.join(irisDocDir, 'fmt_config', fmtConfig);
-
   exportFilePath = path.resolve(exportFilePath);
 
   if (language === 'dart') {
@@ -63,6 +53,16 @@ function irisDocScript(
       console.log(e);
     }
   }
+
+  let requirementsPath = path.join(irisDocDir, 'requirements.txt');
+  let installRequirements = `python3 -m pip install -r ${requirementsPath}`;
+  const installRequirementsOut = execSync(installRequirements, {
+    encoding: 'utf8',
+    stdio: 'inherit',
+  });
+  console.log(installRequirementsOut);
+
+  let fmtConfigPath = path.join(irisDocDir, 'fmt_config', fmtConfig);
 
   let irisDocScriptPath = path.join(irisDocDir, 'iris_doc.py');
   let irisDocCommand = `python3 ${irisDocScriptPath} --config=${fmtConfigPath} --language=${language} --export-file-path=${exportFilePath} --template-url=${templateUrl}`;

--- a/src/renderers/iris_doc_renderer.ts
+++ b/src/renderers/iris_doc_renderer.ts
@@ -50,6 +50,20 @@ function irisDocScript(
 
   exportFilePath = path.resolve(exportFilePath);
 
+  if (language === 'dart') {
+    // TODO(littlegnal): Maybe move to the `iris_doc.py` script.
+    // The `iris_doc.py` script relies on the formatted file, we format the files before running the script to ensure the script run correctly.
+    try {
+      execSync(`dart format ${path.dirname(exportFilePath)}`, {
+        encoding: 'utf8',
+        stdio: 'inherit',
+      });
+    } catch (e) {
+      // Allow failed.
+      console.log(e);
+    }
+  }
+
   let irisDocScriptPath = path.join(irisDocDir, 'iris_doc.py');
   let irisDocCommand = `python3 ${irisDocScriptPath} --config=${fmtConfigPath} --language=${language} --export-file-path=${exportFilePath} --template-url=${templateUrl}`;
 


### PR DESCRIPTION
The `iris_doc.py` script relies on the formatted file, we format the files before running the script to ensure the script runs correctly.

This change only applies to the `language === 'dart'` at this time.