### PR TITLE
Keep IRtcEngineEventHandlerEx.onFirstLocalVideoFramePublished

### DIFF
--- a/configs/rtc/remove_node_list.ts
+++ b/configs/rtc/remove_node_list.ts
@@ -56,7 +56,6 @@ module.exports = [
   'agora::rtc::IRtcEngineEventHandler.eventHandlerType',
   'agora::rtc::IRtcEngineEventHandlerEx.eventHandlerType',
   'agora::rtc::IRtcEngineEventHandlerEx.onFirstLocalVideoFrame',
-  'agora::rtc::IRtcEngineEventHandlerEx.onFirstLocalVideoFramePublished',
   'agora::rtc::IRtcEngineEventHandlerEx.onLocalVideoStateChanged',
   'agora::rtc::IMediaPlayer.initialize',
   'agora::rtc::IMediaPlayer.openWithCustomSource',


### PR DESCRIPTION
See internal task CSD-67677, we should keep `IRtcEngineEventHandlerEx.onFirstLocalVideoFramePublished` callback instead.